### PR TITLE
Have IK target ball reattach to the end-effector when the user stops interacting 

### DIFF
--- a/Runtime/Scripts/SetupIK.cs
+++ b/Runtime/Scripts/SetupIK.cs
@@ -73,6 +73,7 @@ public class SetupIK : MonoBehaviour
 
         grabInteractable.selectExited.AddListener((SelectExitEventArgs interactor) => {
             ccdIK.active = false;
+            target.transform.position = lastChild.transform.position;
         });
     }
 


### PR DESCRIPTION
## Describe your changes

What is the purpose of this part of the project? Which assets and/or scripts are you adding or editing? Describe below.

Snaps IK target back to the robot's last link position on the end of the user interaction.
fixes https://github.com/parasollab/VR_Robot/issues/20 
#

## Checklist before requesting a review

Fill in by placing an x between the brackets below.

- [x ] I have performed a self-review of my code
- [x ] I have merged the master branch into my branch so it is up to date
- [x ] I have verified that the code will build and run
- [ x] I have checked that my changes do not conflict with other team members' work
- [ ] I have added or edited pages on the wiki to reflect these changes

## Anything else we should know?

Any issues introduced by these changes or bugs we should be aware of? Describe below or mark "N/A".

### A grad student will review your changes and either approve and merge them or request changes. Please be responsive if changes are requested. Thanks!
